### PR TITLE
Fix issue with commands

### DIFF
--- a/lua/maestro/sv_commands.lua
+++ b/lua/maestro/sv_commands.lua
@@ -113,6 +113,10 @@ function maestro.runcmd(silent, cmd, args, ply)
 	end
 	local endarg
 	for i = 1, #args do
+		if args[i]:len() == 0 then
+			continue
+		end
+		
 		local arg = maestro.commands[cmd].args[i]
 		if not arg then
 			if not endarg then


### PR DESCRIPTION
Basically entering commands in chat with no arguments would result in an empty string, might just be my chatbox but it's nice to have nontheless.
