### PR TITLE
Fix !banid

### DIFF
--- a/lua/maestro/plugins/sh_bans.lua
+++ b/lua/maestro/plugins/sh_bans.lua
@@ -10,7 +10,7 @@ maestro.command("ban", {"player:target", "time", "reason"}, function(caller, tar
 end, [[
 Bans the player for the specified time and reason.]])
 maestro.command("banid", {"steamid", "time", "reason"}, function(caller, id, time, reason)
-	maestro.ban(id, time, reason, caller)
+	maestro.ban(util.SteamIDTo64(id), time, reason, caller)
 	return false, "banned %1 for %2 (%3)"
 end, [[
 Bans the SteamID for the specified time and reason.


### PR DESCRIPTION
#### Current Behavior: 
The banid command doesn't work according to documentation, or the other ban functions that accept a SteamID (unban, banlogid).  It should be accepting a SteamID (SteamId2), but (seemingly accidentally) only supports a SteamID64.
It also fails silently when providing an invalid SteamId format, which is why it took me this long to notice.
#### Changed Behavior: 
The banid command now accepts a normal SteamID string like all similar commands.