### PR TITLE
Fix banning admin record

### DIFF
--- a/lua/maestro/sv_bans.lua
+++ b/lua/maestro/sv_bans.lua
@@ -58,8 +58,9 @@ function maestro.ban(id, time, reason, adminid)
 			end
 		end)
 	q:Execute()
-
+	maestro.bans[id] = true
 end
+
 function maestro.unban(id, reason, adminid)
 	local q = mysql:Update(maestro.config.tables.bans)
 		q:Update("unbanid", adminid or 0)
@@ -75,6 +76,7 @@ function maestro.unban(id, reason, adminid)
 		q:Where("until", 0)
 		q:Where("unban", "")
 	q:Execute()
+	maestro.bans[id] = nil
 end
 
 maestro.hook("CheckPassword", "bans", function(id64)
@@ -90,6 +92,9 @@ maestro.hook("CheckPassword", "bans", function(id64)
 				local last = res[1]
 				local unban = " (" .. maestro.time(last["until"] - os.time(), 2) .. " remaining)"
 				game.ConsoleCommand("kickid " .. id .. " Banned: " .. string.sub(last.reason:gsub(";", ":"), 1, 255 - 8 - #unban) .. unban .. "\n")
+				maestro.bans[id64] = true
+			else
+				maestro.bans[id64] = nil
 			end
 		end)
 	q:Execute()
@@ -102,6 +107,9 @@ maestro.hook("CheckPassword", "bans", function(id64)
 				local last = res[1]
 				local unban = "\n(" .. maestro.time(last["until"] - os.time(), 2) .. " remaining)"
 				game.ConsoleCommand("kickid " .. id .. " Permabanned: " .. last.reason:gsub(";", ":") .. "\n")
+				maestro.bans[id64] = true
+			else
+				maestro.bans[id64] = nil
 			end
 		end)
 	q:Execute()

--- a/lua/maestro/sv_bans.lua
+++ b/lua/maestro/sv_bans.lua
@@ -10,7 +10,7 @@ function maestro.ban(id, time, reason, adminid)
 		ply = player.GetBySteamID64(id) or 0
 	end
 	local admin
-	if type(id) == "Player" then
+	if type(adminid) == "Player" then
 		admin = adminid
 		adminid = adminid:SteamID64() or 0
 	end

--- a/lua/maestro/sv_messages.lua
+++ b/lua/maestro/sv_messages.lua
@@ -1,7 +1,7 @@
 maestro.hook("CheckPassword", "maestro_messages", function(id64, ip, sv, cl, name)
 	local id = util.SteamIDFrom64(id64)
-	local ban = maestro.bans and maestro.bans[id] or false
-	if ban and ban.unban > os.time() then
+	local ban = maestro.bans and maestro.bans[id64] or false
+	if ban then
 		return
 	end
 	if sv ~= "" and sv ~= cl then


### PR DESCRIPTION
There appears to be a logic error in `maestro.ban` where the banned player is checked twice, instead of the banning admin, resulting in logic fall-through where the admin player object is serialized directly into the database.
https://github.com/Ottworks/maestro/blob/aadf349796222b57cfa9e94c733ec19834257f2b/lua/maestro/sv_bans.lua#L13-L16
This breaks how other commands interpret the `admin` and `adminid` field, the former being blank and the latter containing something like `Player [2][Glitchvid]`.

Additionally, while logic exists to suppress the player join message for banned players, it appears to never have been hooked up.

**Changed behavior:**
The ban function will now check the adminid, and run the logic to assign the correct variables; setting `admin` to the player, and the `adminid` to their steamid64.

Additionally, the ban functions will also now set the global banned player table, and check it in the join message hook; suppressing banned player join attempt spam.

Unfortunately without more work (db migrations, version change and update) the existing banned player tables will still contain incorrect data, however that should just exhibit as a gap in records and not produce any errors.