### PR TITLE
Fix '@' targeting self

### DIFF
--- a/lua/maestro/sh_target.lua
+++ b/lua/maestro/sh_target.lua
@@ -90,7 +90,7 @@ function maestro.target(val, ply, cmd)
 			start = ply:GetShootPos(),
 			endpos = ply:GetShootPos() + ply:EyeAngles():Forward() * 1024,
 			filter = function(ent)
-				return ent:GetClass() ~= "Player"
+				return ent:GetClass() == "player" and ent ~= ply
 			end,
 		}
 		if IsValid(tr.Entity) and tr.Entity:IsPlayer() then


### PR DESCRIPTION
Currently the '@' targeting special function doesn't properly filter its trace, allowing it to hit any type of entity, and more often than not, usually self-target the person running the command.
**Changed Behavior:**
The trace filter now only allows hitting players, and will filter out the person running the command.